### PR TITLE
compress output

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
-
 bin/viamboatmodule: go.mod *.go cmd/module/*.go
-	go build -o bin/viamboatmodule cmd/module/cmd.go
+	go build -ldflags "-s -w" -o $@ ./cmd/module
+	upx -9 $@
 
 bin/viamboat: go.mod *.go cmd/remote/*.go
 	go build -o bin/viamboat cmd/remote/cmd.go

--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
 bin/viamboatmodule: go.mod *.go cmd/module/*.go
+	go build -o bin/viamboatmodule cmd/module/cmd.go
+
+bin/viamboatmodule-upx: go.mod *.go cmd/module/*.go
 	go build -ldflags "-s -w" -o $@ ./cmd/module
 	upx -9 $@
 


### PR DESCRIPTION
## What changed
Added new makefile target `bin/viamboatmodule-upx` which strips symbols + applies upx compression
## Why
Smaller binary size for slow cellular connections